### PR TITLE
未ログイン時のユーザーエリア内ページへアクセスした場合の挙動変更

### DIFF
--- a/kokemomo/plugins/engine/controller/km_access_check.py
+++ b/kokemomo/plugins/engine/controller/km_access_check.py
@@ -3,6 +3,7 @@
 
 from functools import wraps
 from xml.sax.saxutils import *
+from kokemomo.lib.bottle import redirect
 from kokemomo.plugins.engine.model.km_user_table import find as find_user
 from kokemomo.plugins.engine.model.km_role_table import find as find_role
 from kokemomo.plugins.engine.controller.km_db_manager import *
@@ -80,7 +81,7 @@ def check_login(request, response):
                     login_info = user_id in session
                     if login_info and session[user_id] is not u'':
                         return callback(*args, **kwargs)
-                return "<p>Not Logged!</p>" # TODO: 例外スロー時にエラー画面に遷移するようにする
+                return redirect('/engine/login?errorcode=0')
         return wrapper
     return _check_login
 

--- a/kokemomo/plugins/engine/view/resource/js/login.js
+++ b/kokemomo/plugins/engine/view/resource/js/login.js
@@ -7,6 +7,11 @@ $(document).ready(function(){
 	    send(SendType[2], '/engine/login/auth', loginInfo , login);
 	});
 
+	var return_parameter = getParameter("errorcode");
+	if (return_parameter == 0) {
+	    $("#error_label").removeClass('hidden');
+        $("#error_label").text('不正なアクセスです。ログインして下さい。');
+    }
 });
 
 function login(status, json){
@@ -25,3 +30,21 @@ function login(status, json){
         }
     }
 }
+
+function getParameter(param_key){
+	var ret = null;
+	var url = location.href; 
+	parameters = url.split("?");
+
+	if( parameters.length > 1 ) {
+		var params   = parameters[1].split("&");
+		var paramsArray = [];
+		for ( i = 0; i < params.length; i++ ) {
+		   var param_data = params[i].split("=");
+		   paramsArray.push(param_data[0]);
+		   paramsArray[param_data[0]] = param_data[1];
+		}
+		ret = paramsArray[param_key];
+	}
+    return ret;
+};


### PR DESCRIPTION
現状では未ログイン時に任意のユーザーエリア内のページへアクセスするとエラーページが表示される。
しかし、エラーページ表示後は特にアクションは行われず、ログイン画面へのアクセスはユーザに直接アクセスしてもらわなければならない。

そこで、UXを高めるため未ログイン時にユーザエリア内へアクセスがあった場合はログイン画面へリダイレクトし、エラーラベルを表示するように修正しました。
