### PR TITLE
モデルバリデーションの仕組みを実装

### DIFF
--- a/kokemomo/plugins/engine/controller/km_storage/impl/km_rdb_adapter.py
+++ b/kokemomo/plugins/engine/controller/km_storage/impl/km_rdb_adapter.py
@@ -18,7 +18,12 @@ class BaseModel(object):
     def __repr__(self):
         return '<%s>' % self.__class__.__name__
 
-    def save(self):
+    def validate(self):
+        pass
+
+    def save(self, validate=True):
+        if validate:
+            self.validate()
         try:
             adapter.add(self)
             adapter.commit()

--- a/test/plugins/engine/test_rdb_adapter.py
+++ b/test/plugins/engine/test_rdb_adapter.py
@@ -9,6 +9,9 @@ from sqlalchemy.exc import SQLAlchemyError
 class User(adapter.Model):
     name = adapter.Column(adapter.String(50))
 
+    def validate(self):
+        self.name = self.name.lower() # for test
+
 class SimpleTestCase(unittest.TestCase):
     def setUp(self):
         initialize(rdb_path='sqlite:///:memory:')
@@ -62,3 +65,13 @@ class SimpleTestCase(unittest.TestCase):
         john = User(id=999,name='jonh')
         john.save()
         self.assertEqual(2, len(User.all()))
+
+    def test_validation(self):
+        steve = User(name='STEVE')
+        steve.save()
+        self.assertEqual('steve', steve.name)
+
+    def test_no_validation(self):
+        steve = User(name='STEVE')
+        steve.save(validate=False)
+        self.assertNotEqual('steve', steve.name)


### PR DESCRIPTION
モデルによってはバリデーション関数を実装しないパターンも考えられるので、`validate`関数の実装が必須になるような作り方(abc module)にはしていません:bow:

-
Closes #62